### PR TITLE
Start of the QBE backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "mlc",
     "midlang",
     "json_frontend",
+    "qbe_backend",
 ]
 
 resolver = "2"

--- a/midlang/src/lib.rs
+++ b/midlang/src/lib.rs
@@ -1,19 +1,10 @@
-pub enum Type {
-    Int32,
-    Str,
-}
-
-pub enum Visibility {
-    Public,
-    Private,
-}
-
 pub enum MidLang {
     Module(String, Vec<Decl>),
 }
 
-pub enum FuncArg {
-    Named(String, Type),
+pub enum Decl {
+    FwdDecl(String, Visibility, Type, FuncArgs),
+    FuncDecl(String, Visibility, Type, FuncArgs, Vec<Stmt>),
 }
 
 pub enum FuncArgs {
@@ -21,9 +12,8 @@ pub enum FuncArgs {
     Variadic(FuncArg, Vec<FuncArg>),
 }
 
-pub enum Decl {
-    FwdDecl(String, Visibility, Type, FuncArgs),
-    FuncDecl(String, Visibility, Type, FuncArgs, Vec<Stmt>),
+pub enum FuncArg {
+    Named(String, Type),
 }
 
 pub enum Stmt {
@@ -35,4 +25,14 @@ pub enum Expr {
     ConstInt32(i32),
     ConstStr(String),
     FuncCall(String, Type, Vec<Expr>),
+}
+
+pub enum Visibility {
+    Public,
+    Private,
+}
+
+pub enum Type {
+    Int32,
+    Str,
 }

--- a/mlc/Cargo.toml
+++ b/mlc/Cargo.toml
@@ -10,3 +10,4 @@ clap = { version = "4.4.13", features = ["derive"] }
 
 json_frontend = { path = "../json_frontend" }
 midlang = { path = "../midlang" }
+qbe_backend = { "path" = "../qbe_backend" }

--- a/mlc/src/main.rs
+++ b/mlc/src/main.rs
@@ -2,7 +2,8 @@ use std::error::Error;
 
 use clap::Parser;
 
-use json_frontend::{lower, parse_file_named};
+use json_frontend;
+use qbe_backend;
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -12,8 +13,9 @@ struct Args {
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
-    let json_module = parse_file_named(&args.json_file)?;
-    let _midlang_module = lower(&json_module)?;
+    let json_module = json_frontend::parse_file_named(&args.json_file)?;
+    let midlang_module = json_frontend::lower(&json_module)?;
+    let _ = qbe_backend::lower(&midlang_module);
 
     println!("Parsed {}", args.json_file);
 

--- a/qbe_backend/Cargo.toml
+++ b/qbe_backend/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "qbe_backend"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/qbe_backend/Cargo.toml
+++ b/qbe_backend/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+midlang = { path = "../midlang" }

--- a/qbe_backend/src/lib.rs
+++ b/qbe_backend/src/lib.rs
@@ -28,7 +28,7 @@ pub enum Stmt {
 }
 
 pub enum Expr {
-    Value,
+    Value(Value),
     FuncCall(String, Type, Vec<Value>),
 }
 
@@ -114,12 +114,26 @@ fn lower_stmts(stmts: &Vec<m::Stmt>) -> Vec<Stmt> {
         .collect()
 }
 
-fn lower_expr(_expr: &m::Expr) -> (Vec<Stmt>, Expr) {
+fn lower_exprs_to_values(_exprs: &Vec<m::Expr>) -> (Vec<Stmt>, Vec<Value>) {
     todo!()
 }
 
 fn lower_expr_to_value(_expr: &m::Expr) -> (Vec<Stmt>, Value) {
     todo!()
+}
+
+fn lower_expr(expr: &m::Expr) -> (Vec<Stmt>, Expr) {
+    match expr {
+        m::Expr::ConstInt32(i) => (vec![], Expr::Value(Value::ConstW(*i))),
+        m::Expr::ConstStr(_) => todo!(),
+        m::Expr::FuncCall(name, r#type, args) => {
+            let (stmts, values) = lower_exprs_to_values(args);
+            (
+                stmts,
+                Expr::FuncCall(name.to_string(), lower_type(r#type), values),
+            )
+        }
+    }
 }
 
 fn lower_visibility(visibility: &m::Visibility) -> Option<Linkage> {

--- a/qbe_backend/src/lib.rs
+++ b/qbe_backend/src/lib.rs
@@ -1,3 +1,5 @@
+use midlang as m;
+
 pub enum LowerLang {
     CompUnit(String, Vec<Decl>),
 }
@@ -51,4 +53,50 @@ pub enum Type {
 pub enum Scope {
     Func,
     Global,
+}
+
+pub fn lower(midlang: &m::MidLang) -> LowerLang {
+    match midlang {
+        m::MidLang::Module(name, decls) => {
+            LowerLang::CompUnit(name.to_string(), lower_decls(decls))
+        }
+    }
+}
+
+fn lower_decls(decls: &Vec<m::Decl>) -> Vec<Decl> {
+    decls
+        .iter()
+        .filter_map(|d| match d {
+            m::Decl::FuncDecl(name, visibility, r#type, args, stmts) => Some(Decl::FuncDecl(
+                name.to_string(),
+                lower_visibility(visibility),
+                lower_type(r#type),
+                lower_args(args),
+                lower_stmts(stmts),
+            )),
+            m::Decl::FwdDecl(_, _, _, _) => None,
+        })
+        .collect()
+}
+
+fn lower_args(_args: &m::FuncArgs) -> FuncArgs {
+    todo!()
+}
+
+fn lower_stmts(_stmts: &Vec<m::Stmt>) -> Vec<Stmt> {
+    todo!()
+}
+
+fn lower_visibility(visibility: &m::Visibility) -> Option<Linkage> {
+    match visibility {
+        m::Visibility::Public => Some(Linkage::Export),
+        m::Visibility::Private => None,
+    }
+}
+
+fn lower_type(r#type: &m::Type) -> Type {
+    match r#type {
+        m::Type::Int32 => Type::W,
+        m::Type::Str => Type::L,
+    }
 }

--- a/qbe_backend/src/lib.rs
+++ b/qbe_backend/src/lib.rs
@@ -79,8 +79,21 @@ fn lower_decls(decls: &Vec<m::Decl>) -> Vec<Decl> {
         .collect()
 }
 
-fn lower_args(_args: &m::FuncArgs) -> FuncArgs {
-    todo!()
+fn lower_args(args: &m::FuncArgs) -> FuncArgs {
+    fn lower(args: &Vec<m::FuncArg>) -> Vec<FuncArg> {
+        args.iter().map(|a| lower_arg(a)).collect()
+    }
+
+    match args {
+        m::FuncArgs::Fixed(args) => FuncArgs::Fixed(lower(args)),
+        m::FuncArgs::Variadic(first, rest) => FuncArgs::Variadic(lower_arg(first), lower(rest)),
+    }
+}
+
+fn lower_arg(arg: &m::FuncArg) -> FuncArg {
+    match arg {
+        m::FuncArg::Named(name, r#type) => FuncArg::Named(name.to_string(), lower_type(r#type)),
+    }
 }
 
 fn lower_stmts(_stmts: &Vec<m::Stmt>) -> Vec<Stmt> {

--- a/qbe_backend/src/lib.rs
+++ b/qbe_backend/src/lib.rs
@@ -154,14 +154,13 @@ fn lower_exprs_to_values(
     exprs: &Vec<m::Expr>,
     str_pool: &mut StringPool,
 ) -> (Vec<Stmt>, Vec<Value>) {
-    let results: Vec<_> = exprs
+    let (stmts, values): (Vec<Vec<_>>, Vec<_>) = exprs
         .iter()
         .map(|e| lower_expr_to_value(e, str_pool))
-        .collect();
+        .unzip();
+    let stmts = stmts.into_iter().flatten().collect();
 
-    let (stmts, values): (Vec<Vec<_>>, Vec<_>) = results.into_iter().unzip();
-
-    (stmts.into_iter().flatten().collect(), values)
+    (stmts, values)
 }
 
 fn lower_expr_to_value(expr: &m::Expr, str_pool: &mut StringPool) -> (Vec<Stmt>, Value) {

--- a/qbe_backend/src/lib.rs
+++ b/qbe_backend/src/lib.rs
@@ -1,0 +1,54 @@
+pub enum LowerLang {
+    CompUnit(String, Vec<Decl>),
+}
+
+pub enum Decl {
+    Data(String, Vec<(Type, String)>),
+    FuncDecl(String, Option<Linkage>, Type, FuncArgs, Vec<Stmt>),
+}
+
+pub enum FuncArgs {
+    Fixed(Vec<FuncArg>),
+    Variadic(FuncArg, Vec<FuncArg>),
+}
+
+pub enum FuncArg {
+    Named(String, Type),
+}
+
+pub enum Stmt {
+    FuncCall(String, Vec<Value>),
+    Jmp(String),
+    Jnz(Expr, String, String),
+    Lbl(String),
+    Ret(Expr),
+    VarDecl(String, Type, Scope, Expr),
+}
+
+pub enum Expr {
+    Value,
+    FuncCall(String, Type, Vec<Value>),
+}
+
+pub enum Value {
+    ConstW(i32),
+    VarRef(String, Type, Scope),
+}
+
+pub enum Linkage {
+    Export,
+}
+
+pub enum Type {
+    B,
+    D,
+    H,
+    L,
+    S,
+    W,
+}
+
+pub enum Scope {
+    Func,
+    Global,
+}

--- a/qbe_backend/src/lib.rs
+++ b/qbe_backend/src/lib.rs
@@ -23,8 +23,8 @@ pub enum Stmt {
     Jmp(String),
     Jnz(Expr, String, String),
     Lbl(String),
-    Ret(Expr),
-    VarDecl(String, Type, Scope, Expr),
+    Ret(Value),
+    VarDecl(String, Scope, Expr),
 }
 
 pub enum Expr {
@@ -96,7 +96,29 @@ fn lower_arg(arg: &m::FuncArg) -> FuncArg {
     }
 }
 
-fn lower_stmts(_stmts: &Vec<m::Stmt>) -> Vec<Stmt> {
+fn lower_stmts(stmts: &Vec<m::Stmt>) -> Vec<Stmt> {
+    stmts
+        .iter()
+        .flat_map(|s| match s {
+            m::Stmt::Ret(expr) => {
+                let (mut stmts, value) = lower_expr_to_value(expr);
+                stmts.push(Stmt::Ret(value));
+                stmts
+            }
+            m::Stmt::VarDecl(name, expr) => {
+                let (mut stmts, expr) = lower_expr(expr);
+                stmts.push(Stmt::VarDecl(name.to_string(), Scope::Func, expr));
+                stmts
+            }
+        })
+        .collect()
+}
+
+fn lower_expr(_expr: &m::Expr) -> (Vec<Stmt>, Expr) {
+    todo!()
+}
+
+fn lower_expr_to_value(_expr: &m::Expr) -> (Vec<Stmt>, Value) {
     todo!()
 }
 


### PR DESCRIPTION
Adding the lower language for the QBE backend and lowering the middle language to it. This will make the upcoming IR generation easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Reorganized code structure for clarity and maintainability.
	- Updated import paths and usage of core functions to align with the new code organization.

- **New Features**
	- Extended existing enums with new variants to enhance language expression capabilities.

- **Documentation**
	- Adjusted code comments to reflect the changes in structure and logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->