### PR TITLE
Start to split up files

### DIFF
--- a/json_frontend/src/json_lang.rs
+++ b/json_frontend/src/json_lang.rs
@@ -1,0 +1,74 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum JSONLang {
+    Module { name: String, decls: Vec<Decl> },
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Decl {
+    FwdDecl {
+        name: String,
+        visibility: Visibility,
+        r#type: Type,
+        args: FuncArgs,
+    },
+    FuncDecl {
+        name: String,
+        visibility: Visibility,
+        r#type: Type,
+        args: FuncArgs,
+        stmts: Vec<Stmt>,
+    },
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FuncArgs {
+    Fixed(Vec<FuncArg>),
+    Variadic(FuncArg, Vec<FuncArg>),
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FuncArg {
+    Named { name: String, r#type: Type },
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Stmt {
+    Ret { value: Expr },
+    VarDecl { name: String, value: Expr },
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Expr {
+    Const {
+        value: Value,
+        r#type: Type,
+    },
+    FuncCall {
+        name: String,
+        r#type: Type,
+        args: Vec<Expr>,
+    },
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Visibility {
+    Public,
+    Private,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Type {
+    Int32,
+    Str,
+}

--- a/json_frontend/src/lib.rs
+++ b/json_frontend/src/lib.rs
@@ -3,82 +3,13 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
 
-use serde::Deserialize;
 use serde_json::Value;
 
 use midlang as m;
 
-#[derive(Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum JSONLang {
-    Module { name: String, decls: Vec<Decl> },
-}
+mod json_lang;
 
-#[derive(Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Decl {
-    FwdDecl {
-        name: String,
-        visibility: Visibility,
-        r#type: Type,
-        args: FuncArgs,
-    },
-    FuncDecl {
-        name: String,
-        visibility: Visibility,
-        r#type: Type,
-        args: FuncArgs,
-        stmts: Vec<Stmt>,
-    },
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Type {
-    Int32,
-    Str,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Visibility {
-    Public,
-    Private,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum FuncArg {
-    Named { name: String, r#type: Type },
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum FuncArgs {
-    Fixed(Vec<FuncArg>),
-    Variadic(FuncArg, Vec<FuncArg>),
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Stmt {
-    Ret { value: Expr },
-    VarDecl { name: String, value: Expr },
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Expr {
-    Const {
-        value: Value,
-        r#type: Type,
-    },
-    FuncCall {
-        name: String,
-        r#type: Type,
-        args: Vec<Expr>,
-    },
-}
+use json_lang::*;
 
 type Res<T> = Result<T, Box<dyn Error>>;
 

--- a/qbe_backend/src/lower_lang.rs
+++ b/qbe_backend/src/lower_lang.rs
@@ -1,0 +1,79 @@
+pub enum LowerLang {
+    CompUnit(String, Vec<Decl>),
+}
+
+pub type DataField = (Type, String);
+
+pub enum Decl {
+    Data(String, Vec<DataField>),
+    FuncDecl(String, Option<Linkage>, Type, FuncArgs, Vec<Stmt>),
+}
+
+pub enum FuncArgs {
+    Fixed(Vec<FuncArg>),
+    Variadic(FuncArg, Vec<FuncArg>),
+}
+
+pub enum FuncArg {
+    Named(String, Type),
+}
+
+pub enum Stmt {
+    FuncCall(String, Vec<Value>),
+    Jmp(String),
+    Jnz(Expr, String, String),
+    Lbl(String),
+    Ret(Value),
+    VarDecl(String, Scope, Expr),
+}
+
+pub enum Expr {
+    Value(Value),
+    FuncCall(String, Type, Vec<Value>),
+}
+
+pub enum Value {
+    ConstW(i32),
+    VarRef(String, Type, Scope),
+}
+
+pub enum Linkage {
+    Export,
+}
+
+#[derive(Clone, Copy)]
+pub enum Type {
+    B,
+    D,
+    H,
+    L,
+    S,
+    W,
+}
+
+pub enum Scope {
+    Func,
+    Global,
+}
+
+pub trait Typed {
+    fn r#type(&self) -> Type;
+}
+
+impl Typed for Expr {
+    fn r#type(&self) -> Type {
+        match self {
+            Expr::Value(value) => value.r#type(),
+            Expr::FuncCall(_, r#type, _) => *r#type,
+        }
+    }
+}
+
+impl Typed for Value {
+    fn r#type(&self) -> Type {
+        match self {
+            Value::ConstW(_) => Type::W,
+            Value::VarRef(_, r#type, _) => *r#type,
+        }
+    }
+}

--- a/qbe_backend/src/lowering_context.rs
+++ b/qbe_backend/src/lowering_context.rs
@@ -1,0 +1,48 @@
+use std::collections::BTreeMap;
+
+use crate::lower_lang::*;
+
+pub struct LoweringCtx {
+    prefix: String,
+    pool: BTreeMap<String, String>,
+    uniq: u32,
+}
+
+impl LoweringCtx {
+    pub fn new(prefix: &str) -> LoweringCtx {
+        LoweringCtx {
+            prefix: prefix.to_string(),
+            pool: Default::default(),
+            uniq: 0,
+        }
+    }
+
+    pub fn uniq_name(&mut self, prefix: &str) -> String {
+        let name = format!("{}{}", prefix, self.uniq);
+        self.uniq += 1;
+        name
+    }
+
+    pub fn name_for_str(&mut self, str: &str) -> String {
+        let len = self.pool.len();
+        self.pool
+            .entry(str.to_string())
+            .or_insert_with(|| format!("{}_{}", self.prefix, len))
+            .to_string()
+    }
+
+    pub fn decls(&self) -> Vec<Decl> {
+        fn fields(value: &str) -> Vec<DataField> {
+            vec![(Type::B, value.to_string()), (Type::B, "0".to_string())]
+        }
+
+        self.pool
+            .iter()
+            .map(|(k, v)| Decl::Data(k.to_string(), fields(v)))
+            .collect()
+    }
+
+    pub fn decls_len(&self) -> usize {
+        self.pool.len()
+    }
+}


### PR DESCRIPTION
Start to split up `json_frontend/src/lib,rs` and `qbe_backend/src/lib.rs`. Can't take it much further until #5 is done, since `mlc/src/main.rs` calls directly into the front and backend for initial dev testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new deserialization capabilities for a custom language's syntax.
  - Enhanced backend code organization with separate modules for improved readability and maintenance.
  - Added a new context structure for managing the lowering process in the backend.

- **Refactor**
  - Replaced existing enums related to JSON language parsing with a more structured module.
  - Refactored the backend's `lower` function to utilize new context methods for better code management.

- **Chores**
  - Codebase reorganization by moving specific modules into separate files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->