### PR TITLE
Port the QBE IL writer from Supreme Spoon

### DIFF
--- a/midlang/src/compiler.rs
+++ b/midlang/src/compiler.rs
@@ -1,14 +1,18 @@
-use std::collections::HashMap;
 use std::error::Error;
 
 use crate::middle_lang::MidLang;
 
+pub type FrontendResult = Result<MidLang, Box<dyn Error>>;
+
 pub trait Frontend {
-    fn parse(&self) -> Result<MidLang, Box<dyn Error>>;
+    fn parse(&self) -> FrontendResult;
 }
 
+pub type FileNameAndContents = (String, String);
+pub type BackendResult = Result<Vec<FileNameAndContents>, Box<dyn Error>>;
+
 pub trait Backend {
-    fn generate_build_artifacts(&self, midlang: &MidLang) -> HashMap<String, String>;
+    fn generate_build_artifacts(&self, midlang: &MidLang) -> BackendResult;
 }
 
 pub struct Compiler<'a> {
@@ -22,8 +26,8 @@ pub fn new<'a>(frontend: &'a dyn Frontend, backend: &'a dyn Backend) -> Compiler
 
 impl Compiler<'_> {
     pub fn compile(&self) -> Result<(), Box<dyn Error>> {
-        let midlang_module = self.frontend.parse()?;
-        let _ = self.backend.generate_build_artifacts(&midlang_module);
+        let midlang = self.frontend.parse()?;
+        let _ = self.backend.generate_build_artifacts(&midlang)?;
 
         Ok(())
     }

--- a/qbe_backend/src/il.rs
+++ b/qbe_backend/src/il.rs
@@ -1,0 +1,152 @@
+use std::fmt;
+use std::fmt::Write;
+
+use midlang::compiler::FileNameAndContents;
+
+use crate::lower_lang::*;
+
+const IL_BUFFER_CAPACITY: usize = 1024;
+const INDENT: &str = "    ";
+
+pub fn generate_il(lower_lang: &LowerLang) -> Result<Vec<FileNameAndContents>, fmt::Error> {
+    match lower_lang {
+        LowerLang::CompUnit(name, decls) => Ok(vec![(filename(name), decls_il(decls)?)]),
+    }
+}
+
+fn filename(name: &str) -> String {
+    format!("{}.il", name)
+}
+
+fn decls_il(decls: &[Decl]) -> Result<String, fmt::Error> {
+    let mut il = String::with_capacity(IL_BUFFER_CAPACITY);
+
+    for decl in decls {
+        append_decl_il(decl, &mut il)?;
+    }
+
+    Ok(il)
+}
+
+fn append_decl_il(decl: &Decl, il: &mut impl Write) -> fmt::Result {
+    match decl {
+        Decl::Data(name, fields) => {
+            write!(il, "data ${} = {{ ", name)?;
+
+            for (i, (r#type, value)) in fields.iter().enumerate() {
+                if i > 0 {
+                    il.write_str(", ")?;
+                }
+
+                write!(il, "{} {}", r#type, value)?;
+            }
+
+            il.write_str(" }\n")?;
+        }
+        Decl::FuncDecl(name, linkage, r#type, args, stmts) => {
+            if let Some(linkage) = linkage {
+                write!(il, "{} ", linkage)?;
+            }
+
+            write!(il, "function {} ${}(", r#type, name)?;
+
+            append_func_args_il(args, il)?;
+
+            il.write_str(") {\n")?;
+
+            append_stmts_il(stmts, il)?;
+
+            il.write_str("}\n")?;
+        }
+    }
+
+    Ok(())
+}
+
+fn append_func_args_il(args: &FuncArgs, il: &mut impl Write) -> fmt::Result {
+    match args {
+        FuncArgs::Fixed(args) => {
+            for (i, arg) in args.iter().enumerate() {
+                if i > 0 {
+                    il.write_str(", ")?;
+                }
+                append_func_arg_il(arg, il)?;
+            }
+        }
+        FuncArgs::Variadic(first, rest) => {
+            append_func_arg_il(first, il)?;
+
+            for arg in rest {
+                il.write_str(", ")?;
+                append_func_arg_il(arg, il)?;
+            }
+
+            il.write_str(", ...")?;
+        }
+    }
+
+    Ok(())
+}
+
+fn append_func_arg_il(arg: &FuncArg, il: &mut impl Write) -> fmt::Result {
+    match arg {
+        FuncArg::Named(name, r#type) => write!(il, "{} %{}", r#type, name)?,
+    }
+
+    Ok(())
+}
+
+fn append_stmts_il(stmts: &[Stmt], il: &mut impl Write) -> fmt::Result {
+    for stmt in stmts {
+        match stmt {
+            Stmt::Lbl(name) => write!(il, "@{}", name)?,
+            Stmt::Ret(value) => {
+                write!(il, "{}ret ", INDENT)?;
+                append_value_il(value, false, il)?;
+            }
+            Stmt::VarDecl(name, scope, expr) => {
+                write!(il, "{}{}{} ={} ", INDENT, scope, name, expr.r#type())?;
+                append_expr_il(expr, false, il)?;
+            }
+        }
+
+        il.write_str("\n")?;
+    }
+
+    Ok(())
+}
+
+fn append_expr_il(expr: &Expr, type_consts: bool, il: &mut impl Write) -> fmt::Result {
+    match expr {
+        Expr::Value(value) => append_value_il(value, type_consts, il)?,
+        Expr::FuncCall(name, _, values) => {
+            write!(il, "call ${}(", name)?;
+
+            for (i, value) in values.iter().enumerate() {
+                if i > 0 {
+                    il.write_str(", ")?;
+                }
+
+                append_value_il(value, true, il)?;
+            }
+
+            il.write_str(")")?;
+        }
+    }
+
+    Ok(())
+}
+
+fn append_value_il(value: &Value, type_consts: bool, il: &mut impl Write) -> fmt::Result {
+    match value {
+        Value::ConstW(v) => {
+            if type_consts {
+                write!(il, "{} ", Type::W)?;
+            }
+            write!(il, "{}", v)?;
+        }
+        Value::VarRef(name, r#type, scope) => write!(il, "{} {}{}", r#type, scope, name)?,
+    }
+
+    Ok(())
+}

--- a/qbe_backend/src/lib.rs
+++ b/qbe_backend/src/lib.rs
@@ -1,11 +1,10 @@
-use std::collections::HashMap;
-
+mod il;
 mod lower;
 mod lower_lang;
 mod lowering_context;
 
+use il::generate_il;
 use lower::lower;
-
 use midlang::compiler;
 use midlang::middle_lang as m;
 
@@ -16,9 +15,65 @@ pub fn new() -> Backend {
 }
 
 impl compiler::Backend for Backend {
-    fn generate_build_artifacts(&self, midlang: &m::MidLang) -> HashMap<String, String> {
-        let _ = lower(midlang);
+    fn generate_build_artifacts(&self, midlang: &m::MidLang) -> compiler::BackendResult {
+        let lower_lang = lower(midlang);
+        Ok(generate_il(&lower_lang)?)
+    }
+}
 
-        Default::default()
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+    use std::fs::read_to_string;
+    use std::path::Path;
+
+    use midlang::compiler::Backend as _;
+
+    type TestResult = Result<(), Box<dyn Error>>;
+
+    #[test]
+    fn hello_world() -> TestResult {
+        let midlang = m::MidLang::Module(
+            "hello_world".to_string(),
+            vec![
+                m::Decl::FwdDecl(
+                    "puts".to_string(),
+                    m::Visibility::Public,
+                    m::Type::Int32,
+                    m::FuncArgs::Fixed(vec![m::FuncArg::Named("s".to_string(), m::Type::Str)]),
+                ),
+                m::Decl::FuncDecl(
+                    "main".to_string(),
+                    m::Visibility::Public,
+                    m::Type::Int32,
+                    m::FuncArgs::Fixed(vec![]),
+                    vec![
+                        m::Stmt::VarDecl(
+                            "r".to_string(),
+                            m::Expr::FuncCall(
+                                "puts".to_string(),
+                                m::Type::Int32,
+                                vec![m::Expr::ConstStr("hello world".to_string())],
+                            ),
+                        ),
+                        m::Stmt::Ret(m::Expr::ConstInt32(0)),
+                    ],
+                ),
+            ],
+        );
+
+        let ba = new().generate_build_artifacts(&midlang)?;
+        assert_eq!(ba.len(), 1);
+        assert_eq!(ba[0].0, "hello_world.il");
+
+        let path = Path::new(env!("TEST_CASES_DIR"))
+            .join("qbe")
+            .join("hello_world.il");
+        let expected_il = read_to_string(&path)?;
+
+        assert_eq!(ba[0].1, expected_il);
+
+        Ok(())
     }
 }

--- a/qbe_backend/src/lower_lang.rs
+++ b/qbe_backend/src/lower_lang.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+use std::fmt::{Display, Formatter};
+
 pub enum LowerLang {
     CompUnit(String, Vec<Decl>),
 }
@@ -19,6 +22,7 @@ pub enum FuncArg {
 }
 
 pub enum Stmt {
+    Lbl(String),
     Ret(Value),
     VarDecl(String, Scope, Expr),
 }
@@ -67,6 +71,33 @@ impl Typed for Value {
         match self {
             Value::ConstW(_) => Type::W,
             Value::VarRef(_, r#type, _) => *r#type,
+        }
+    }
+}
+
+impl Display for Linkage {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::Export => write!(f, "export"),
+        }
+    }
+}
+
+impl Display for Scope {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::Func => write!(f, "%"),
+            Self::Global => write!(f, "$"),
+        }
+    }
+}
+
+impl Display for Type {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::B => write!(f, "b"),
+            Self::L => write!(f, "l"),
+            Self::W => write!(f, "w"),
         }
     }
 }

--- a/qbe_backend/src/lowering_context.rs
+++ b/qbe_backend/src/lowering_context.rs
@@ -27,18 +27,21 @@ impl LoweringCtx {
         let len = self.pool.len();
         self.pool
             .entry(str.to_string())
-            .or_insert_with(|| format!("{}_{}", self.prefix, len))
+            .or_insert_with(|| format!("{}_str{}", self.prefix, len))
             .to_string()
     }
 
     pub fn decls(&self) -> Vec<Decl> {
         fn fields(value: &str) -> Vec<DataField> {
-            vec![(Type::B, value.to_string()), (Type::B, "0".to_string())]
+            vec![
+                (Type::B, format!("\"{}\"", value)),
+                (Type::B, "0".to_string()),
+            ]
         }
 
         self.pool
             .iter()
-            .map(|(k, v)| Decl::Data(k.to_string(), fields(v)))
+            .map(|(k, v)| Decl::Data(v.to_string(), fields(k)))
             .collect()
     }
 

--- a/test_cases/qbe/hello_world.il
+++ b/test_cases/qbe/hello_world.il
@@ -1,0 +1,6 @@
+data $hello_world_str0 = { b "hello world", b 0 }
+export function w $main() {
+@start
+    %r =w call $puts(l $hello_world_str0)
+    ret 0
+}


### PR DESCRIPTION
Fixes #6 

Ports the QBE IL writing logic from Supreme Spoon. The QBE backend can now generate IL for the hello world example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type aliasing for result types in the compiler's frontend and backend.
	- Introduced intermediate language (IL) generation functionality.

- **Improvements**
	- Streamlined parsing and artifact generation methods in the compiler workflow.
	- Refined the process of lowering high-level language constructs to IL.

- **Tests**
	- Added a new test case to demonstrate "hello world" functionality.

- **Documentation**
	- Implemented display traits for better debugging and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->