### PR TITLE
Allow specifying output file name and libraries to link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ hello-world2:
 		--json-file $(TEST_CASES_DIR)/json/hello_world2.json \
 		--build-dir $(BUILD_DIR)/hello_world2 \
 		--ninja samu \
+		-o hello_world \
 	&& $(IN_DEV) $(BUILD_DIR)/hello_world2/a.out
 
 hello-world-cond:
@@ -67,7 +68,8 @@ hello-world-cond:
 		--json-file $(TEST_CASES_DIR)/json/hello_world_cond.json \
 		--build-dir $(BUILD_DIR)/hello_world_cond \
 		--ninja samu \
-	&& $(IN_DEV) $(BUILD_DIR)/hello_world_cond/a.out
+		-o hello_world \
+	&& $(IN_DEV) $(BUILD_DIR)/hello_world_cond/hello_world
 
 usage:
 	$(IN_DEV) $(MLC) --help

--- a/mlc/src/main.rs
+++ b/mlc/src/main.rs
@@ -10,12 +10,25 @@ struct Args {
     build_dir: String,
     #[arg(short, long)]
     ninja: String,
+    #[arg(short, long = "library")]
+    libraries: Option<Vec<String>>,
+    #[arg(short = 'L', long = "library-path")]
+    library_paths: Option<Vec<String>>,
+    #[arg(short, long)]
+    output: Option<String>,
 }
+
+const DEFAULT_OUTPUT: &str = "a.out";
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
     let frontend = json_frontend::new(&args.json_file);
-    let backend = qbe_backend::new();
+
+    let libraries = args.libraries.unwrap_or_else(Vec::new);
+    let library_paths = args.library_paths.unwrap_or_else(Vec::new);
+    let output = args.output.unwrap_or_else(|| DEFAULT_OUTPUT.to_string());
+    let backend = qbe_backend::new(&libraries, &library_paths, &output);
+
     let compiler = compiler::new(&frontend, &backend, &args.build_dir, &args.ninja);
 
     compiler.compile()


### PR DESCRIPTION
Fixes #27 - allow specifying the output file name, library search paths and libraries to link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the build system to allow custom output file naming.
	- Introduced command-line arguments for library specification and output control in the main application.
	- Updated the backend library to handle new build configuration options and improved link flag management.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->