### PR TITLE
Fixes needed during Supreme Spoon integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,5 @@ RUN rustup component add rustfmt clippy
 RUN \
     --mount=type=cache,target=/var/cache/cargo \
     cargo build
+
+RUN cargo install --path mlc

--- a/compiler/src/type_check.rs
+++ b/compiler/src/type_check.rs
@@ -84,10 +84,12 @@ fn check_stmts<'a>(
     for stmt in stmts {
         match stmt {
             Stmt::Cond(cases) => {
-                for (expr, _) in cases {
+                for (expr, stmts) in cases {
                     if *expr.r#type() != Type::Bool {
                         return Err("Cond case expressions must be of type bool".into());
                     }
+                    let mut cond_vars = vars.clone();
+                    check_stmts(stmts, func_type, fwd_decls, &mut cond_vars)?;
                 }
             }
             Stmt::FuncCall(_, exprs) => check_exprs(exprs, fwd_decls, vars)?,
@@ -111,7 +113,7 @@ fn check_stmts<'a>(
     Ok(())
 }
 
-fn check_exprs(exprs: &[Expr], fwd_decls: &FwdDecls, vars: &mut Vars) -> Res<()> {
+fn check_exprs(exprs: &[Expr], fwd_decls: &FwdDecls, vars: &Vars) -> Res<()> {
     for expr in exprs {
         check_expr(expr, fwd_decls, vars)?;
     }
@@ -119,7 +121,7 @@ fn check_exprs(exprs: &[Expr], fwd_decls: &FwdDecls, vars: &mut Vars) -> Res<()>
     Ok(())
 }
 
-fn check_expr(expr: &Expr, fwd_decls: &FwdDecls, vars: &mut Vars) -> Res<()> {
+fn check_expr(expr: &Expr, fwd_decls: &FwdDecls, vars: &Vars) -> Res<()> {
     fn func_call_type_err(name: &str) -> Res<()> {
         Err(format!(
             "FuncCall '{}' type does not match forward declaration",

--- a/qbe_backend/src/il.rs
+++ b/qbe_backend/src/il.rs
@@ -141,30 +141,28 @@ fn append_stmts_il(stmts: &[Stmt], il: &mut impl Write) -> fmt::Result {
     Ok(())
 }
 
-fn append_expr_il(expr: &Expr, type_consts: bool, il: &mut impl Write) -> fmt::Result {
+fn append_expr_il(expr: &Expr, type_values: bool, il: &mut impl Write) -> fmt::Result {
     match expr {
-        Expr::Value(value) => append_value_il(value, type_consts, il)?,
+        Expr::Value(value) => append_value_il(value, type_values, il)?,
         Expr::FuncCall(name, _, values) => append_func_call_il(name, values, false, il)?,
     }
 
     Ok(())
 }
 
-fn append_value_il(value: &Value, type_consts: bool, il: &mut impl Write) -> fmt::Result {
+fn append_value_il(value: &Value, type_values: bool, il: &mut impl Write) -> fmt::Result {
+    if type_values {
+        write!(il, "{} ", value.r#type())?;
+    }
+
     match value {
         Value::ConstL(v) => {
-            if type_consts {
-                write!(il, "{} ", value.r#type())?;
-            }
             write!(il, "{}", v)?;
         }
         Value::ConstW(v) => {
-            if type_consts {
-                write!(il, "{} ", value.r#type())?;
-            }
             write!(il, "{}", v)?;
         }
-        Value::VarRef(name, r#type, scope) => write!(il, "{} {}{}", r#type, scope, name)?,
+        Value::VarRef(name, _, scope) => write!(il, "{}{}", scope, name)?,
     }
 
     Ok(())


### PR DESCRIPTION
While Supreme Spoon was integrating with `mlc` a few issues came up, fixing them below. The main resolutions were:

1. Make sure the `mlc` binary is present in the docker image via a `cargo install`
2. When writing QBE IL, literal values set to temporaries need to be "copied" (%x =w copy 0 for instance)
3. When writing QBE IL, it is possible that all RHS values need to be typed, not just constants
4. When type checking `Cond` statements, type check each case's statements with a clone of the current var scope. This keeps vars defined inside a `Case` local to that case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced conditional logic processing in the compiler.
- **Refactor**
  - Improved internal rendering mechanisms for better performance and reliability.
- **Chores**
  - Updated the build environment with necessary dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->