### PR TITLE
Double Great

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ test-compile:
 		--json-file $(TEST_CASES_DIR)/json/$(TEST_CASE).json \
 		--build-dir $(BUILD_DIR)/$(TEST_CASE) \
 		--ninja $(NINJA) \
+		-lm \
 		-o $(TEST_CASE)
 
 test-run:

--- a/compiler/src/type_check.rs
+++ b/compiler/src/type_check.rs
@@ -146,7 +146,11 @@ fn check_expr(expr: &Expr, fwd_decls: &FwdDecls, vars: &Vars) -> Res<()> {
     }
 
     match expr {
-        Expr::ConstBool(_) | Expr::ConstInt32(_) | Expr::ConstInt64(_) | Expr::ConstStr(_) => (),
+        Expr::ConstBool(_)
+        | Expr::ConstDouble(_)
+        | Expr::ConstInt32(_)
+        | Expr::ConstInt64(_)
+        | Expr::ConstStr(_) => (),
         Expr::VarRef(name, r#type) => match vars.get(&name as &str) {
             Some(expr_type) if *expr_type != r#type => {
                 return Err(format!("VarRef '{}' type does not match its declaration", name).into())

--- a/integration.mk
+++ b/integration.mk
@@ -1,7 +1,8 @@
 TESTS := \
 	hello_world \
 	hello_world2 \
-	hello_world_cond
+	hello_world_cond \
+	math
 
 $(TESTS):
 	make TEST_CASE=$@ test-compile test-run && \

--- a/integration.mk
+++ b/integration.mk
@@ -2,7 +2,7 @@ TESTS := \
 	hello_world \
 	hello_world2 \
 	hello_world_cond \
-	math
+	fabs
 
 $(TESTS):
 	make TEST_CASE=$@ test-compile test-run && \

--- a/json_frontend/src/json_lang.rs
+++ b/json_frontend/src/json_lang.rs
@@ -86,6 +86,7 @@ pub enum Visibility {
 #[serde(rename_all = "lowercase")]
 pub enum Type {
     Bool,
+    Double,
     Int32,
     Int64,
     Ptr,

--- a/json_frontend/src/lib.rs
+++ b/json_frontend/src/lib.rs
@@ -82,7 +82,7 @@ mod tests {
     fn math() -> TestResult {
         let path = Path::new(env!("TEST_CASES_DIR"))
             .join("json")
-            .join("math.json");
+            .join("fabs.json");
         let filename = &path.display().to_string();
 
         new(&filename).parse()?;

--- a/json_frontend/src/lib.rs
+++ b/json_frontend/src/lib.rs
@@ -77,4 +77,16 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn math() -> TestResult {
+        let path = Path::new(env!("TEST_CASES_DIR"))
+            .join("json")
+            .join("math.json");
+        let filename = &path.display().to_string();
+
+        new(&filename).parse()?;
+
+        Ok(())
+    }
 }

--- a/json_frontend/src/lower.rs
+++ b/json_frontend/src/lower.rs
@@ -74,6 +74,7 @@ fn lower_visibility(visibility: &Visibility) -> m::Visibility {
 fn lower_type(r#type: &Type) -> m::Type {
     match r#type {
         Type::Bool => m::Type::Bool,
+        Type::Double => m::Type::Double,
         Type::Int32 => m::Type::Int32,
         Type::Int64 => m::Type::Int64,
         Type::Ptr => m::Type::Ptr,
@@ -148,7 +149,13 @@ fn lower_number(num: &serde_json::value::Number, r#type: &Type) -> Res<m::Expr> 
             .ok_or_else(|| Box::from("Number is not an Int64"))
     }
 
+    fn as_f64(num: &serde_json::value::Number) -> Res<f64> {
+        num.as_f64()
+            .ok_or_else(|| Box::from("Number is not a Double"))
+    }
+
     match (num, r#type) {
+        (n, Type::Double) => Ok(m::Expr::ConstDouble(as_f64(n)?)),
         (n, Type::Int32) => Ok(m::Expr::ConstInt32(as_i32(n)?)),
         (n, Type::Int64) => Ok(m::Expr::ConstInt64(as_i64(n)?)),
         _ => Err(Box::from("Invalid number value and type")),

--- a/midlang/src/lib.rs
+++ b/midlang/src/lib.rs
@@ -28,6 +28,7 @@ pub enum Stmt {
 
 pub enum Expr {
     ConstBool(bool),
+    ConstDouble(f64),
     ConstInt32(i32),
     ConstInt64(i64),
     ConstStr(String),
@@ -44,6 +45,7 @@ pub enum Visibility {
 #[derive(PartialEq)]
 pub enum Type {
     Bool,
+    Double,
     Int32,
     Int64,
     Ptr,
@@ -54,6 +56,7 @@ impl Expr {
     pub fn r#type(&self) -> &Type {
         match self {
             Self::ConstBool(_) => &Type::Bool,
+            Self::ConstDouble(_) => &Type::Double,
             Self::ConstInt32(_) => &Type::Int32,
             Self::ConstInt64(_) => &Type::Int64,
             Self::ConstStr(_) => &Type::Str,

--- a/mtc/src/lib.rs
+++ b/mtc/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod hello_world;
+pub mod math;
 pub mod snippets;
 
 pub use hello_world::*;
+pub use math::*;
 pub use snippets::*;

--- a/mtc/src/math.rs
+++ b/mtc/src/math.rs
@@ -1,0 +1,37 @@
+use midlang::*;
+
+pub fn fabs() -> Vec<Module> {
+    vec![Module {
+        name: "fabs".to_string(),
+        decls: vec![
+            Decl::FwdDecl(
+                "printf".to_string(),
+                Visibility::Public,
+                Some(Type::Int32),
+                vec![("fmt".to_string(), Type::Str)],
+                true,
+            ),
+            Decl::FuncDecl(
+                "main".to_string(),
+                Visibility::Public,
+                Some(Type::Int32),
+                vec![],
+                false,
+                vec![
+                    Stmt::FuncCall(
+                        "printf".to_string(),
+                        vec![
+                            Expr::ConstStr("The fabs of -1.23 is %f\n".to_string()),
+                            Expr::FuncCall(
+                                "fabs".to_string(),
+                                Type::Double,
+                                vec![Expr::ConstDouble(-1.23)],
+                            ),
+                        ],
+                    ),
+                    Stmt::Ret(Some(Expr::ConstInt32(0))),
+                ],
+            ),
+        ],
+    }]
+}

--- a/qbe_backend/src/il.rs
+++ b/qbe_backend/src/il.rs
@@ -160,6 +160,13 @@ fn append_value_il(value: &Value, render_flags: u8, il: &mut impl Write) -> fmt:
     }
 
     match value {
+        Value::ConstD(v) => {
+            if render_flags & RENDER_VALUE_COPY_LITERALS != 0 {
+                il.write_str("copy ")?;
+            }
+
+            write!(il, "d_{}", v)?;
+        }
         Value::ConstL(v) => {
             if render_flags & RENDER_VALUE_COPY_LITERALS != 0 {
                 il.write_str("copy ")?;

--- a/qbe_backend/src/lib.rs
+++ b/qbe_backend/src/lib.rs
@@ -70,7 +70,7 @@ fn configure_ninja_build(
 ) {
     let qbe = ninja_writer.rule("qbe", "qbe -o $out $in");
     let cc = ninja_writer.rule("cc", "cc -o $out -c $in");
-    let link = ninja_writer.rule("link", "cc -o $out $link_flags $in");
+    let link = ninja_writer.rule("link", "cc -o $out $in $link_flags");
     let mut objs = Vec::<String>::with_capacity(build_artifacts.len());
 
     for (il, _) in build_artifacts {

--- a/qbe_backend/src/lib.rs
+++ b/qbe_backend/src/lib.rs
@@ -201,4 +201,29 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn fabs() -> TestResult {
+        let modules = mtc::fabs();
+
+        let mut ninja_writer = Ninja::new();
+        let ba = generate_build_artifacts(&modules, &mut ninja_writer)?;
+        assert_eq!(ba.len(), 1);
+        assert_eq!(ba[0].0, "fabs.il");
+
+        let path = Path::new(env!("TEST_CASES_DIR"))
+            .join("qbe")
+            .join("fabs.il");
+        let expected_il = read_to_string(&path)?;
+
+        assert_eq!(ba[0].1, expected_il);
+
+        let ninja_build = ninja_writer.to_string();
+        assert!(ninja_build.contains("fabs.il"));
+        assert!(ninja_build.contains("fabs.s"));
+        assert!(ninja_build.contains("fabs.o"));
+        assert!(ninja_build.contains("a.out"));
+
+        Ok(())
+    }
 }

--- a/qbe_backend/src/lower.rs
+++ b/qbe_backend/src/lower.rs
@@ -110,6 +110,7 @@ fn lower_expr_to_value(expr: &m::Expr, stmts: &mut Vec<Stmt>, ctx: &mut Lowering
     match expr {
         m::Expr::ConstBool(true) => Value::ConstW(1),
         m::Expr::ConstBool(false) => Value::ConstW(0),
+        m::Expr::ConstDouble(d) => Value::ConstD(*d),
         m::Expr::ConstInt32(i) => Value::ConstW(*i),
         m::Expr::ConstInt64(i) => Value::ConstL(*i),
         m::Expr::ConstStr(s) => {
@@ -134,6 +135,7 @@ fn lower_expr_to_value(expr: &m::Expr, stmts: &mut Vec<Stmt>, ctx: &mut Lowering
 fn lower_expr(expr: &m::Expr, stmts: &mut Vec<Stmt>, ctx: &mut LoweringCtx) -> Expr {
     match expr {
         m::Expr::ConstBool(_)
+        | m::Expr::ConstDouble(_)
         | m::Expr::ConstInt32(_)
         | m::Expr::ConstInt64(_)
         | m::Expr::ConstStr(_)
@@ -165,6 +167,7 @@ fn lower_visibility(visibility: &m::Visibility) -> Option<Linkage> {
 
 fn lower_type(r#type: &m::Type) -> Type {
     match r#type {
+        m::Type::Double => Type::D,
         m::Type::Bool | m::Type::Int32 => Type::W,
         m::Type::Int64 | m::Type::Ptr | m::Type::Str => Type::L,
     }

--- a/qbe_backend/src/lower_lang.rs
+++ b/qbe_backend/src/lower_lang.rs
@@ -37,6 +37,7 @@ pub enum Expr {
 }
 
 pub enum Value {
+    ConstD(f64),
     ConstL(i64),
     ConstW(i32),
     VarRef(String, Type, Scope),
@@ -49,6 +50,7 @@ pub enum Linkage {
 #[derive(Clone, Copy)]
 pub enum Type {
     B,
+    D,
     L,
     W,
 }
@@ -74,6 +76,7 @@ impl Typed for Expr {
 impl Typed for Value {
     fn r#type(&self) -> Type {
         match self {
+            Value::ConstD(_) => Type::D,
             Value::ConstL(_) => Type::L,
             Value::ConstW(_) => Type::W,
             Value::VarRef(_, r#type, _) => *r#type,
@@ -102,6 +105,7 @@ impl Display for Type {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             Self::B => write!(f, "b"),
+            Self::D => write!(f, "d"),
             Self::L => write!(f, "l"),
             Self::W => write!(f, "w"),
         }

--- a/qbe_backend/src/lowering_context.rs
+++ b/qbe_backend/src/lowering_context.rs
@@ -34,7 +34,7 @@ impl LoweringCtx {
     pub fn decls(&self) -> Vec<Decl> {
         fn fields(value: &str) -> Vec<DataField> {
             vec![
-                (Type::B, format!("\"{}\"", value)),
+                (Type::B, format!("\"{}\"", str::replace(value, "\n", "\\n"))),
                 (Type::B, "0".to_string()),
             ]
         }

--- a/test_cases/json/fabs.json
+++ b/test_cases/json/fabs.json
@@ -1,7 +1,7 @@
 {
   "modules": [
     {
-      "name": "math",
+      "name": "fabs",
       "decls": [
         {
           "fwddecl": {
@@ -45,7 +45,7 @@
                   "args": [
                     {
                       "const": {
-                        "value": "The fabs of -3.14 is %f\n",
+                        "value": "The fabs of -1.23 is %f\n",
                         "type": "str"
                       }
                     },
@@ -56,7 +56,7 @@
                         "args": [
                           {
                             "const": {
-                              "value": -3.14,
+                              "value": -1.23,
                               "type": "double"
                             }
                           }

--- a/test_cases/json/math.json
+++ b/test_cases/json/math.json
@@ -1,0 +1,85 @@
+{
+  "modules": [
+    {
+      "name": "math",
+      "decls": [
+        {
+          "fwddecl": {
+            "name": "printf",
+            "visibility": "public",
+            "type": "int32",
+            "args": [
+              {
+                "name": "format",
+                "type": "str"
+              }
+            ],
+            "variadic": true
+          }
+        },
+        {
+          "fwddecl": {
+            "name": "fabs",
+            "visibility": "public",
+            "type": "double",
+            "args": [
+              {
+                "name": "x",
+                "type": "double"
+              }
+            ]
+          }
+        },
+        {
+          "funcdecl": {
+            "name": "main",
+            "visibility": "public",
+            "type": "int32",
+            "args": [],
+            "variadic": false,
+            "stmts": [
+              {
+                "funccall": {
+                  "name": "printf",
+                  "type": "int32",
+                  "args": [
+                    {
+                      "const": {
+                        "value": "The fabs of -3.14 is %f\n",
+                        "type": "str"
+                      }
+                    },
+                    {
+                      "funccall": {
+                        "name": "fabs",
+                        "type": "double",
+                        "args": [
+                          {
+                            "const": {
+                              "value": -3.14,
+                              "type": "double"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "ret": {
+                  "value": {
+                    "const": {
+                      "value": 0,
+                      "type": "int32"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_cases/qbe/fabs.il
+++ b/test_cases/qbe/fabs.il
@@ -1,0 +1,7 @@
+data $fabs_str0 = { b "The fabs of -1.23 is %f\n", b 0 }
+export function w $main() {
+@start
+    %arg_0 =d call $fabs(d d_-1.23)
+    call $printf(l $fabs_str0, d %arg_0)
+    ret 0
+}


### PR DESCRIPTION
Fixes #39 - adds a double type to midlang. Added a test case to call `fabs` from `math.h` as an example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for double-precision floating-point constants in expressions.
  - Added a new test case to validate mathematical operations with double-precision floats.

- **Bug Fixes**
  - Adjusted build configuration to correctly link mathematical libraries.

- **Documentation**
  - Updated internal test documentation to include the new `math` test case.

- **Refactor**
  - Enhanced various internal components to handle double-precision floating-point types.
  - Improved code generation for floating-point constants in the backend.

- **Style**
  - Modified string formatting to ensure newline characters are correctly represented in outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->