### PR TITLE
Add support for pass by reference, give pointers types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ME := $(MY_USER):$(MY_GROUP)
 
 RUSTFLAGS ?=
 TEST_CASES_DIR ?= test_cases
-TEST_CASE ?= hello_world
+TEST_CASE ?= frexp
 BUILD_DIR ?= build
 NINJA ?= ninja
 MLC ?= ./target/debug/mlc
@@ -13,9 +13,7 @@ DOCKER_RUN_COMMON := --env RUSTFLAGS="$(RUSTFLAGS)" --env-file ./docker.env -v .
 IN_DEV ?= docker run $(DOCKER_RUN_COMMON)
 IN_IDEV ?= docker run -it $(DOCKER_RUN_COMMON)
 
-include integration.mk
-
-all: dev-env compile tests hello-world usage
+all: dev-env compile hello_world
 
 dev-env:
 	docker build --progress=plain -t $(DOCKER_IMG) .
@@ -48,7 +46,7 @@ check: fmt-check clippy-check
 clean:
 	@rm -rf $(BUILD_DIR)
 
-start: hello_world_cond
+start: $(TEST_CASE)
 	@/bin/true
 
 test-compile:
@@ -78,5 +76,7 @@ check-ownership:
 	dev-env sh \
 	compile test start clean \
 	fmt fmt-check fmt-json clippy clippy-check check \
-	check-ownership take-ownership  usage \
+	check-ownership take-ownership usage \
 	test-compile test-run
+
+include integration.mk

--- a/integration.mk
+++ b/integration.mk
@@ -2,7 +2,8 @@ TESTS := \
 	hello_world \
 	hello_world2 \
 	hello_world_cond \
-	fabs
+	fabs \
+	frexp
 
 $(TESTS):
 	make TEST_CASE=$@ test-compile test-run && \

--- a/json_frontend/src/json_lang.rs
+++ b/json_frontend/src/json_lang.rs
@@ -72,6 +72,7 @@ pub enum Expr {
     VarRef {
         name: String,
         r#type: Type,
+        byref: Option<bool>,
     },
 }
 
@@ -89,6 +90,7 @@ pub enum Type {
     Double,
     Int32,
     Int64,
-    Ptr,
+    Ptr { to: Box<Type> },
     Str,
+    VoidPtr,
 }

--- a/json_frontend/src/lower.rs
+++ b/json_frontend/src/lower.rs
@@ -77,7 +77,8 @@ fn lower_type(r#type: &Type) -> m::Type {
         Type::Double => m::Type::Double,
         Type::Int32 => m::Type::Int32,
         Type::Int64 => m::Type::Int64,
-        Type::Ptr => m::Type::Ptr,
+        Type::Ptr { to: r#type } => m::Type::Ptr(Some(Box::new(lower_type(r#type)))),
+        Type::VoidPtr => m::Type::Ptr(None),
         Type::Str => m::Type::Str,
     }
 }
@@ -132,7 +133,15 @@ fn lower_expr(expr: &Expr) -> Res<m::Expr> {
             lower_type(r#type),
             lower_exprs(args)?,
         )),
-        Expr::VarRef { name, r#type } => Ok(m::Expr::VarRef(name.to_string(), lower_type(r#type))),
+        Expr::VarRef {
+            name,
+            r#type,
+            byref,
+        } => Ok(m::Expr::VarRef(
+            name.to_string(),
+            lower_type(r#type),
+            byref.unwrap_or(false),
+        )),
     }
 }
 

--- a/midlang/src/lib.rs
+++ b/midlang/src/lib.rs
@@ -33,7 +33,7 @@ pub enum Expr {
     ConstInt64(i64),
     ConstStr(String),
     FuncCall(String, Type, Vec<Expr>),
-    VarRef(String, Type),
+    VarRef(String, Type, bool),
 }
 
 #[derive(PartialEq)]
@@ -48,7 +48,7 @@ pub enum Type {
     Double,
     Int32,
     Int64,
-    Ptr,
+    Ptr(Option<Box<Type>>),
     Str,
 }
 
@@ -61,7 +61,7 @@ impl Expr {
             Self::ConstInt64(_) => &Type::Int64,
             Self::ConstStr(_) => &Type::Str,
             Self::FuncCall(_, r#type, _) => r#type,
-            Self::VarRef(_, r#type) => r#type,
+            Self::VarRef(_, r#type, _) => r#type,
         }
     }
 }

--- a/mtc/src/math.rs
+++ b/mtc/src/math.rs
@@ -11,6 +11,13 @@ pub fn fabs() -> Vec<Module> {
                 vec![("fmt".to_string(), Type::Str)],
                 true,
             ),
+            Decl::FwdDecl(
+                "fabs".to_string(),
+                Visibility::Public,
+                Some(Type::Double),
+                vec![("x".to_string(), Type::Double)],
+                true,
+            ),
             Decl::FuncDecl(
                 "main".to_string(),
                 Visibility::Public,
@@ -27,6 +34,56 @@ pub fn fabs() -> Vec<Module> {
                                 Type::Double,
                                 vec![Expr::ConstDouble(-1.23)],
                             ),
+                        ],
+                    ),
+                    Stmt::Ret(Some(Expr::ConstInt32(0))),
+                ],
+            ),
+        ],
+    }]
+}
+
+pub fn frexp() -> Vec<Module> {
+    vec![Module {
+        name: "frexp".to_string(),
+        decls: vec![
+            Decl::FwdDecl(
+                "printf".to_string(),
+                Visibility::Public,
+                Some(Type::Int32),
+                vec![("fmt".to_string(), Type::Str)],
+                true,
+            ),
+            Decl::FwdDecl(
+                "frexp".to_string(),
+                Visibility::Public,
+                Some(Type::Double),
+                vec![
+                    ("x".to_string(), Type::Double),
+                    ("exp".to_string(), Type::Ptr(Some(Box::new(Type::Int32)))),
+                ],
+                true,
+            ),
+            Decl::FuncDecl(
+                "main".to_string(),
+                Visibility::Public,
+                Some(Type::Int32),
+                vec![],
+                false,
+                vec![
+                    Stmt::VarDecl("exp".to_string(), Expr::ConstInt32(0)),
+                    Stmt::FuncCall(
+                        "frexp".to_string(),
+                        vec![
+                            Expr::ConstDouble(2560.0),
+                            Expr::VarRef("exp".to_string(), Type::Int32, true),
+                        ],
+                    ),
+                    Stmt::FuncCall(
+                        "printf".to_string(),
+                        vec![
+                            Expr::ConstStr("frexp(2560.0, &e); e = %d\n".to_string()),
+                            Expr::VarRef("exp".to_string(), Type::Int32, false),
                         ],
                     ),
                     Stmt::Ret(Some(Expr::ConstInt32(0))),

--- a/mtc/src/snippets.rs
+++ b/mtc/src/snippets.rs
@@ -145,7 +145,7 @@ pub fn var_ref() -> Vec<Module> {
             false,
             vec![
                 Stmt::VarDecl("x".to_string(), Expr::ConstInt32(0)),
-                Stmt::Ret(Some(Expr::VarRef("x".to_string(), Type::Int32))),
+                Stmt::Ret(Some(Expr::VarRef("x".to_string(), Type::Int32, false))),
             ],
         )],
     }]

--- a/qbe_backend/src/il.rs
+++ b/qbe_backend/src/il.rs
@@ -133,6 +133,12 @@ fn append_stmts_il(stmts: &[Stmt], il: &mut impl Write) -> fmt::Result {
                 append_value_il(value, RENDER_VALUE_PLAIN, il)?;
             }
             Stmt::Ret(None) => write!(il, "{}ret", INDENT)?,
+            Stmt::Store(r#type, src, dest) => {
+                write!(il, "{}store{} ", INDENT, r#type)?;
+                append_value_il(src, RENDER_VALUE_PLAIN, il)?;
+                il.write_str(", ")?;
+                append_value_il(dest, RENDER_VALUE_PLAIN, il)?;
+            }
             Stmt::VarDecl(name, scope, expr) => {
                 write!(il, "{}{}{} ={} ", INDENT, scope, name, expr.r#type())?;
                 append_expr_il(expr, RENDER_VALUE_COPY_LITERALS, il)?;
@@ -147,6 +153,11 @@ fn append_stmts_il(stmts: &[Stmt], il: &mut impl Write) -> fmt::Result {
 
 fn append_expr_il(expr: &Expr, value_render_flags: u8, il: &mut impl Write) -> fmt::Result {
     match expr {
+        Expr::Alloc8(bytes) => write!(il, "alloc8 {}", bytes)?,
+        Expr::Load(_, r#type, value) => {
+            write!(il, "load{} ", r#type)?;
+            append_value_il(value, value_render_flags, il)?;
+        }
         Expr::Value(value) => append_value_il(value, value_render_flags, il)?,
         Expr::FuncCall(name, _, values) => append_func_call_il(name, values, false, il)?,
     }

--- a/qbe_backend/src/lib.rs
+++ b/qbe_backend/src/lib.rs
@@ -226,4 +226,29 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn frexp() -> TestResult {
+        let modules = mtc::frexp();
+
+        let mut ninja_writer = Ninja::new();
+        let ba = generate_build_artifacts(&modules, &mut ninja_writer)?;
+        assert_eq!(ba.len(), 1);
+        assert_eq!(ba[0].0, "frexp.il");
+
+        let path = Path::new(env!("TEST_CASES_DIR"))
+            .join("qbe")
+            .join("frexp.il");
+        let expected_il = read_to_string(&path)?;
+
+        assert_eq!(ba[0].1, expected_il);
+
+        let ninja_build = ninja_writer.to_string();
+        assert!(ninja_build.contains("frexp.il"));
+        assert!(ninja_build.contains("frexp.s"));
+        assert!(ninja_build.contains("frexp.o"));
+        assert!(ninja_build.contains("a.out"));
+
+        Ok(())
+    }
 }

--- a/qbe_backend/src/lower_lang.rs
+++ b/qbe_backend/src/lower_lang.rs
@@ -28,10 +28,13 @@ pub enum Stmt {
     Jnz(Value, String, String),
     Lbl(String),
     Ret(Option<Value>),
+    Store(Type, Value, Value),
     VarDecl(String, Scope, Expr),
 }
 
 pub enum Expr {
+    Alloc8(usize),
+    Load(Type, Type, Value),
     Value(Value),
     FuncCall(String, Type, Vec<Value>),
 }
@@ -67,6 +70,8 @@ pub trait Typed {
 impl Typed for Expr {
     fn r#type(&self) -> Type {
         match self {
+            Expr::Alloc8(_) => Type::L,
+            Expr::Load(r#type, _, _) => *r#type,
             Expr::Value(value) => value.r#type(),
             Expr::FuncCall(_, r#type, _) => *r#type,
         }

--- a/qbe_backend/src/lowering_context.rs
+++ b/qbe_backend/src/lowering_context.rs
@@ -2,9 +2,12 @@ use std::collections::BTreeMap;
 
 use crate::lower_lang::*;
 
+pub type TmpRef = (String, String, Type);
+
 pub struct LoweringCtx {
     prefix: String,
     pool: BTreeMap<String, String>,
+    tmp_refs: Vec<Vec<TmpRef>>,
     uniq: u32,
 }
 
@@ -13,12 +16,13 @@ impl LoweringCtx {
         LoweringCtx {
             prefix: prefix.to_string(),
             pool: Default::default(),
+            tmp_refs: Default::default(),
             uniq: 0,
         }
     }
 
     pub fn uniq_name(&mut self, prefix: &str) -> String {
-        let name = format!("{}{}", prefix, self.uniq);
+        let name = format!("..{}..{}", prefix, self.uniq);
         self.uniq += 1;
         name
     }
@@ -47,5 +51,20 @@ impl LoweringCtx {
 
     pub fn decls_len(&self) -> usize {
         self.pool.len()
+    }
+
+    pub fn add_tmp_ref(&mut self, tmp_ref: TmpRef) {
+        let i = self.tmp_refs.len() - 1;
+        self.tmp_refs[i].push(tmp_ref);
+    }
+
+    pub fn push_tmp_refs(&mut self) {
+        self.tmp_refs.push(vec![]);
+    }
+
+    pub fn pop_tmp_refs(&mut self) -> Vec<TmpRef> {
+        self.tmp_refs
+            .pop()
+            .expect("Attempting to pop when tmp_refs is empty")
     }
 }

--- a/test_cases/json/frexp.json
+++ b/test_cases/json/frexp.json
@@ -1,0 +1,117 @@
+{
+  "modules": [
+    {
+      "name": "frexp",
+      "decls": [
+        {
+          "fwddecl": {
+            "name": "printf",
+            "visibility": "public",
+            "type": "int32",
+            "args": [
+              {
+                "name": "format",
+                "type": "str"
+              }
+            ],
+            "variadic": true
+          }
+        },
+        {
+          "fwddecl": {
+            "name": "frexp",
+            "visibility": "public",
+            "type": "double",
+            "args": [
+              {
+                "name": "x",
+                "type": "double"
+              },
+              {
+                "name": "exp",
+                "type": {
+                  "ptr": {
+                    "to": "int32"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "funcdecl": {
+            "name": "main",
+            "visibility": "public",
+            "type": "int32",
+            "args": [],
+            "variadic": false,
+            "stmts": [
+              {
+                "vardecl": {
+                  "name": "exp",
+                  "type": "int32",
+                  "value": {
+                    "const": {
+                      "value": 0,
+                      "type": "int32"
+                    }
+                  }
+                }
+              },
+              {
+                "funccall": {
+                  "name": "frexp",
+                  "args": [
+                    {
+                      "const": {
+                        "value": 2560,
+                        "type": "double"
+                      }
+                    },
+                    {
+                      "varref": {
+                        "name": "exp",
+                        "type": "int32",
+                        "byref": true
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "funccall": {
+                  "name": "printf",
+                  "type": "int32",
+                  "args": [
+                    {
+                      "const": {
+                        "value": "frexp(2560.0, &e); e = %d\n",
+                        "type": "str"
+                      }
+                    },
+                    {
+                      "varref": {
+                        "name": "exp",
+                        "type": "int32"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "ret": {
+                  "value": {
+                    "const": {
+                      "value": 0,
+                      "type": "int32"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_cases/qbe/fabs.il
+++ b/test_cases/qbe/fabs.il
@@ -1,7 +1,7 @@
 data $fabs_str0 = { b "The fabs of -1.23 is %f\n", b 0 }
 export function w $main() {
 @start
-    %arg_0 =d call $fabs(d d_-1.23)
-    call $printf(l $fabs_str0, d %arg_0)
+    %..arg..0 =d call $fabs(d d_-1.23)
+    call $printf(l $fabs_str0, d %..arg..0)
     ret 0
 }

--- a/test_cases/qbe/frexp.il
+++ b/test_cases/qbe/frexp.il
@@ -1,0 +1,11 @@
+data $frexp_str0 = { b "frexp(2560.0, &e); e = %d\n", b 0 }
+export function w $main() {
+@start
+    %exp =w copy 0
+    %..ref..0 =l alloc8 8
+    storew %exp, %..ref..0
+    call $frexp(d d_2560, l %..ref..0)
+    %exp =w loadw %..ref..0
+    call $printf(l $frexp_str0, w %exp)
+    ret 0
+}


### PR DESCRIPTION
Fixes #40 

Added a test case which calls `frexp` from `math.h` passing the `exp` parameter by value. Pointers can now have a type which is type checked to make sure a byref and pointer point to the same type. `json_lang` gets `voidptr` and `ptr` types. Also updated the name generated by `uniq_name` to make it a string that is likely no legal to frontend languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `frexp` operation, enhancing mathematical computation capabilities.
	- Added support for variable references by reference, improving flexibility in variable handling.
- **Bug Fixes**
	- Adjusted type checking for function parameters to ensure type consistency, reducing runtime errors.
- **Tests**
	- Expanded test coverage with new cases for `fabs` and `frexp`, ensuring reliability and correctness.
- **Refactor**
	- Streamlined the build process by updating Makefile targets and removing outdated references.
	- Enhanced internal handling of variable and type representations for better code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->