### PR TITLE
Add support for comparison operators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ME := $(MY_USER):$(MY_GROUP)
 
 RUSTFLAGS ?=
 TEST_CASES_DIR ?= test_cases
-TEST_CASE ?= frexp
+TEST_CASE ?= cmp
 BUILD_DIR ?= build
 NINJA ?= ninja
 MLC ?= ./target/debug/mlc

--- a/integration.mk
+++ b/integration.mk
@@ -3,7 +3,8 @@ TESTS := \
 	hello_world2 \
 	hello_world_cond \
 	fabs \
-	frexp
+	frexp \
+	cmp
 
 $(TESTS):
 	make TEST_CASE=$@ test-compile test-run && \

--- a/json_frontend/src/json_lang.rs
+++ b/json_frontend/src/json_lang.rs
@@ -60,6 +60,10 @@ pub struct Case {
 #[derive(Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Expr {
+    Eq {
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+    },
     Const {
         value: Value,
         r#type: Type,
@@ -68,6 +72,10 @@ pub enum Expr {
         name: String,
         r#type: Type,
         args: Vec<Expr>,
+    },
+    Ne {
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
     },
     VarRef {
         name: String,

--- a/json_frontend/src/lib.rs
+++ b/json_frontend/src/lib.rs
@@ -89,4 +89,16 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn cmp() -> TestResult {
+        let path = Path::new(env!("TEST_CASES_DIR"))
+            .join("json")
+            .join("cmp.json");
+        let filename = &path.display().to_string();
+
+        new(&filename).parse()?;
+
+        Ok(())
+    }
 }

--- a/midlang/src/lib.rs
+++ b/midlang/src/lib.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+use std::fmt::{Display, Formatter};
+
 pub struct Module {
     pub name: String,
     pub decls: Vec<Decl>,
@@ -26,7 +29,9 @@ pub enum Stmt {
     VarDecl(String, Expr),
 }
 
+#[derive(Debug)]
 pub enum Expr {
+    Cmp(Op, Box<Expr>, Box<Expr>),
     ConstBool(bool),
     ConstDouble(f64),
     ConstInt32(i32),
@@ -36,13 +41,19 @@ pub enum Expr {
     VarRef(String, Type, bool),
 }
 
+#[derive(Debug)]
+pub enum Op {
+    Eq,
+    Ne,
+}
+
 #[derive(PartialEq)]
 pub enum Visibility {
     Public,
     Private,
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Type {
     Bool,
     Double,
@@ -55,6 +66,7 @@ pub enum Type {
 impl Expr {
     pub fn r#type(&self) -> &Type {
         match self {
+            Self::Cmp(_, _, _) => &Type::Bool,
             Self::ConstBool(_) => &Type::Bool,
             Self::ConstDouble(_) => &Type::Double,
             Self::ConstInt32(_) => &Type::Int32,
@@ -62,6 +74,15 @@ impl Expr {
             Self::ConstStr(_) => &Type::Str,
             Self::FuncCall(_, r#type, _) => r#type,
             Self::VarRef(_, r#type, _) => r#type,
+        }
+    }
+}
+
+impl Display for Op {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::Eq => write!(f, "eq"),
+            Self::Ne => write!(f, "ne"),
         }
     }
 }

--- a/mtc/src/cmp.rs
+++ b/mtc/src/cmp.rs
@@ -1,0 +1,72 @@
+use midlang::*;
+
+pub fn cmp() -> Vec<Module> {
+    vec![Module {
+        name: "cmp".to_string(),
+        decls: vec![
+            Decl::FwdDecl(
+                "puts".to_string(),
+                Visibility::Public,
+                Some(Type::Int32),
+                vec![("s".to_string(), Type::Str)],
+                false,
+            ),
+            Decl::FwdDecl(
+                "exit".to_string(),
+                Visibility::Public,
+                None,
+                vec![("status".to_string(), Type::Int32)],
+                false,
+            ),
+            Decl::FuncDecl(
+                "main".to_string(),
+                Visibility::Public,
+                Some(Type::Int32),
+                vec![],
+                false,
+                vec![
+                    Stmt::Cond(vec![
+                        (
+                            Expr::Cmp(
+                                Op::Eq,
+                                Box::new(Expr::ConstBool(false)),
+                                Box::new(Expr::ConstBool(true)),
+                            ),
+                            vec![Stmt::FuncCall(
+                                "exit".to_string(),
+                                vec![Expr::ConstInt32(1)],
+                            )],
+                        ),
+                        (
+                            Expr::Cmp(
+                                Op::Eq,
+                                Box::new(Expr::ConstInt32(12)),
+                                Box::new(Expr::ConstInt32(21)),
+                            ),
+                            vec![Stmt::FuncCall(
+                                "exit".to_string(),
+                                vec![Expr::ConstInt32(2)],
+                            )],
+                        ),
+                        (
+                            Expr::Cmp(
+                                Op::Ne,
+                                Box::new(Expr::ConstInt64(12)),
+                                Box::new(Expr::ConstInt64(12)),
+                            ),
+                            vec![Stmt::FuncCall(
+                                "exit".to_string(),
+                                vec![Expr::ConstInt32(3)],
+                            )],
+                        ),
+                    ]),
+                    Stmt::FuncCall(
+                        "puts".to_string(),
+                        vec![Expr::ConstStr("cmp works!".to_string())],
+                    ),
+                    Stmt::Ret(Some(Expr::ConstInt32(0))),
+                ],
+            ),
+        ],
+    }]
+}

--- a/mtc/src/lib.rs
+++ b/mtc/src/lib.rs
@@ -1,7 +1,9 @@
+pub mod cmp;
 pub mod hello_world;
 pub mod math;
 pub mod snippets;
 
+pub use cmp::*;
 pub use hello_world::*;
 pub use math::*;
 pub use snippets::*;

--- a/qbe_backend/src/il.rs
+++ b/qbe_backend/src/il.rs
@@ -154,6 +154,12 @@ fn append_stmts_il(stmts: &[Stmt], il: &mut impl Write) -> fmt::Result {
 fn append_expr_il(expr: &Expr, value_render_flags: u8, il: &mut impl Write) -> fmt::Result {
     match expr {
         Expr::Alloc8(bytes) => write!(il, "alloc8 {}", bytes)?,
+        Expr::Cmp(op, lhs, rhs) => {
+            write!(il, "c{}{} ", op, lhs.r#type())?;
+            append_value_il(lhs, RENDER_VALUE_PLAIN, il)?;
+            il.write_str(", ")?;
+            append_value_il(rhs, RENDER_VALUE_PLAIN, il)?;
+        }
         Expr::Load(_, r#type, value) => {
             write!(il, "load{} ", r#type)?;
             append_value_il(value, value_render_flags, il)?;

--- a/qbe_backend/src/lib.rs
+++ b/qbe_backend/src/lib.rs
@@ -251,4 +251,27 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn cmp() -> TestResult {
+        let modules = mtc::cmp();
+
+        let mut ninja_writer = Ninja::new();
+        let ba = generate_build_artifacts(&modules, &mut ninja_writer)?;
+        assert_eq!(ba.len(), 1);
+        assert_eq!(ba[0].0, "cmp.il");
+
+        let path = Path::new(env!("TEST_CASES_DIR")).join("qbe").join("cmp.il");
+        let expected_il = read_to_string(&path)?;
+
+        assert_eq!(ba[0].1, expected_il);
+
+        let ninja_build = ninja_writer.to_string();
+        assert!(ninja_build.contains("cmp.il"));
+        assert!(ninja_build.contains("cmp.s"));
+        assert!(ninja_build.contains("cmp.o"));
+        assert!(ninja_build.contains("a.out"));
+
+        Ok(())
+    }
 }

--- a/qbe_backend/src/lower_lang.rs
+++ b/qbe_backend/src/lower_lang.rs
@@ -34,6 +34,7 @@ pub enum Stmt {
 
 pub enum Expr {
     Alloc8(usize),
+    Cmp(Op, Value, Value),
     Load(Type, Type, Value),
     Value(Value),
     FuncCall(String, Type, Vec<Value>),
@@ -63,6 +64,11 @@ pub enum Scope {
     Global,
 }
 
+pub enum Op {
+    Eq,
+    Ne,
+}
+
 pub trait Typed {
     fn r#type(&self) -> Type;
 }
@@ -71,6 +77,7 @@ impl Typed for Expr {
     fn r#type(&self) -> Type {
         match self {
             Expr::Alloc8(_) => Type::L,
+            Expr::Cmp(_, _, _) => Type::W,
             Expr::Load(r#type, _, _) => *r#type,
             Expr::Value(value) => value.r#type(),
             Expr::FuncCall(_, r#type, _) => *r#type,
@@ -93,6 +100,15 @@ impl Display for Linkage {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             Self::Export => write!(f, "export"),
+        }
+    }
+}
+
+impl Display for Op {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::Eq => write!(f, "eq"),
+            Self::Ne => write!(f, "ne"),
         }
     }
 }

--- a/test_cases/json/cmp.json
+++ b/test_cases/json/cmp.json
@@ -1,0 +1,174 @@
+{
+  "modules": [
+    {
+      "name": "cmp",
+      "decls": [
+        {
+          "fwddecl": {
+            "name": "puts",
+            "visibility": "public",
+            "type": "int32",
+            "args": [
+              {
+                "name": "s",
+                "type": "str"
+              }
+            ]
+          }
+        },
+        {
+          "fwddecl": {
+            "name": "exit",
+            "visibility": "public",
+            "args": [
+              {
+                "name": "status",
+                "type": "int32"
+              }
+            ]
+          }
+        },
+        {
+          "funcdecl": {
+            "name": "main",
+            "visibility": "public",
+            "type": "int32",
+            "args": [],
+            "variadic": false,
+            "stmts": [
+              {
+                "cond": {
+                  "cases": [
+                    {
+                      "expr": {
+                        "eq": {
+                          "lhs": {
+                            "const": {
+                              "value": false,
+                              "type": "bool"
+                            }
+                          },
+                          "rhs": {
+                            "const": {
+                              "value": true,
+                              "type": "bool"
+                            }
+                          }
+                        }
+                      },
+                      "stmts": [
+                        {
+                          "funccall": {
+                            "name": "exit",
+                            "args": [
+                              {
+                                "const": {
+                                  "value": 1,
+                                  "type": "int32"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "expr": {
+                        "eq": {
+                          "lhs": {
+                            "const": {
+                              "value": 12,
+                              "type": "int32"
+                            }
+                          },
+                          "rhs": {
+                            "const": {
+                              "value": 21,
+                              "type": "int32"
+                            }
+                          }
+                        }
+                      },
+                      "stmts": [
+                        {
+                          "funccall": {
+                            "name": "exit",
+                            "args": [
+                              {
+                                "const": {
+                                  "value": 2,
+                                  "type": "int32"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "expr": {
+                        "ne": {
+                          "lhs": {
+                            "const": {
+                              "value": 12,
+                              "type": "int64"
+                            }
+                          },
+                          "rhs": {
+                            "const": {
+                              "value": 12,
+                              "type": "int64"
+                            }
+                          }
+                        }
+                      },
+                      "stmts": [
+                        {
+                          "funccall": {
+                            "name": "exit",
+                            "args": [
+                              {
+                                "const": {
+                                  "value": 3,
+                                  "type": "int32"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "funccall": {
+                  "name": "puts",
+                  "type": "int32",
+                  "args": [
+                    {
+                      "const": {
+                        "value": "cmp works!",
+                        "type": "str"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "ret": {
+                  "value": {
+                    "const": {
+                      "value": 0,
+                      "type": "int32"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_cases/qbe/cmp.il
+++ b/test_cases/qbe/cmp.il
@@ -1,0 +1,25 @@
+data $cmp_str0 = { b "cmp works!", b 0 }
+export function w $main() {
+@start
+    %..cmp..0 =w ceqw 0, 1
+    jnz %..cmp..0, @cond_case_0, @cond_case_0_end
+@cond_case_0
+    call $exit(w 1)
+    jmp @cond_end
+@cond_case_0_end
+    %..cmp..1 =w ceqw 12, 21
+    jnz %..cmp..1, @cond_case_1, @cond_case_1_end
+@cond_case_1
+    call $exit(w 2)
+    jmp @cond_end
+@cond_case_1_end
+    %..cmp..2 =w cnel 12, 12
+    jnz %..cmp..2, @cond_case_2, @cond_case_2_end
+@cond_case_2
+    call $exit(w 3)
+    jmp @cond_end
+@cond_case_2_end
+@cond_end
+    call $puts(l $cmp_str0)
+    ret 0
+}


### PR DESCRIPTION
Fixes #42 

Adds support for comparison operators, implemented `eq` and `ne` for equal and not equal checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced comparison expressions with equality (`Eq`) and inequality (`Ne`) operations in the language syntax.
  - Expanded the testing suite with a new "cmp" test case for comparison operations.
- **Enhancements**
  - Improved type checking for comparison expressions to ensure type equality between operands.
- **Bug Fixes**
  - Adjusted control flow and logic in the backend to correctly handle comparison expressions.
- **Tests**
  - Added new test functions for type mismatches in comparison expressions and for validating comparison operation handling in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->